### PR TITLE
Chore: added pip install commands to both the docker and vm justfile commands

### DIFF
--- a/justfile
+++ b/justfile
@@ -54,6 +54,9 @@ docker-vs-code: docker-ros
         --name capstone-ros --accept-server-license-terms \
         --cli-data-dir /code-server --no-sleep
 
+docker-pip-install:
+    docker exec capstone-ros pip3 install -r /home/vagrant/ros_ws/src/requirements.txt
+
 # ======================
 # VM
 # ======================
@@ -70,6 +73,9 @@ vm-rebuild:
 
 vm-bash: vm-start
     vagrant ssh
+
+vm-pip-install: vm-start
+    vagrant ssh -c "pip3 install -r /home/vagrant/ros_ws/src/requirements.txt"
 
 # Run 
 vm-vs-code: vm-start


### PR DESCRIPTION
Title says it all; just a quick addition of two `just` commands to make life easier for everyone to install python requirements when you change them.

`just docker-pip-install` and `just vm-pip-install`. They work externally to the envs since I'm not doing any hackery around importing the justfile.